### PR TITLE
fixes #9 - shorten popup url

### DIFF
--- a/src/ui/popup/App.js
+++ b/src/ui/popup/App.js
@@ -74,7 +74,7 @@ class App extends Component {
 						<img style={{
 							height: "1em", width: "1em", margin: "0 10px 0px 13px"
 						}} src={tab.favIconUrl} />
-						<span>{splicedURL}</span>
+						<span>{hostname}</span>
 					</div>
 
 				</div>


### PR DESCRIPTION
shows only the hostname instead of hostname+pathname, which for certain websites may be very long.

fixes https://github.com/History-AutoDelete/History-AutoDelete/issues/61