### PR TITLE
Feature: retroactive delete

### DIFF
--- a/src/ui/settings/components/HistorySettings.js
+++ b/src/ui/settings/components/HistorySettings.js
@@ -7,99 +7,101 @@ import PropTypes from "prop-types";
 import React from "react";
 import Tooltip from "./SettingsTooltip";
 
-const HistorySettings = (props) => {
-	const {
-		style,
-		settings,
-		onUpdateSetting,
-		onResetButtonClick,
-		onResetCounterButtonClick
-	} = props;
-	return (
-		<div style={style}>
-			<h1>History Settings</h1>
-			<div className="row">
-				<div className="col-md-12">
-					<CheckboxSetting
-						text={"Keep History for "}
-						inline={true}
-						settingObject={settings.keepHistory}
-						updateSetting={(payload) => onUpdateSetting(payload)}
-					/>
-					<input
-						type="number"
-						className="form-control"
-						style={{display: "inline"}}
-						onChange={(e) => onUpdateSetting({
-							name: settings.daysToKeep.name, value: e.target.value, id: settings.daysToKeep.id
-						})}
-						value={settings.daysToKeep.value}
-						min="0"
-					/>
-					<span>Day(s)</span>
-					<Tooltip
-						text={`
-              History is cleared on startup and for every hour the browser is open.
-              Does a manual cleanup when turning on for the first time.
-              `} zIndex={3}
-					/>
+class HistorySettings extends React.Component {
+	render() {
+		const {
+			style,
+			settings,
+			onUpdateSetting,
+			onResetButtonClick,
+			onResetCounterButtonClick
+		} = this.props;
+		return (
+			<div style={style}>
+				<h1>History Settings</h1>
+				<div className="row">
+					<div className="col-md-12">
+						<CheckboxSetting
+							text={"Keep History for "}
+							inline={true}
+							settingObject={settings.keepHistory}
+							updateSetting={(payload) => onUpdateSetting(payload)}
+						/>
+						<input
+							type="number"
+							className="form-control"
+							style={{display: "inline"}}
+							onChange={(e) => onUpdateSetting({
+								name: settings.daysToKeep.name, value: e.target.value, id: settings.daysToKeep.id
+							})}
+							value={settings.daysToKeep.value}
+							min="0"
+						/>
+						<span>Day(s)</span>
+						<Tooltip
+							text={`
+				  History is cleared on startup and for every hour the browser is open.
+				  Does a manual cleanup when turning on for the first time.
+				  `} zIndex={3}
+						/>
 
+					</div>
+
+				</div>
+
+				<div className="row">
+					<div className="col-md-9">
+						<CheckboxSetting
+							text={"Log Total Number Of History Deleted"}
+							settingObject={settings.statLogging}
+							inline={true}
+							updateSetting={(payload) => onUpdateSetting(payload)}
+						/>
+						<Tooltip
+							text={"Counts the number of history deleted during this session and in total. This is shown in the Welcome Screen."}
+							zIndex={2}
+						/>
+					</div>
+
+					<div className="col-md-3">
+						<button onClick={() => onResetCounterButtonClick()} className="btn btn-warning" id="resetCounter">
+							<span>Reset Counter</span>
+						</button>
+					</div>
+
+				</div>
+
+				<div className="row">
+					<div className="col-md-12">
+						<CheckboxSetting
+							text={"Show Number of Visits In Browser Icon"}
+							settingObject={settings.showVisitsInIcon}
+							inline={true}
+							updateSetting={(payload) => onUpdateSetting(payload)}
+						/>
+						<Tooltip
+							text={"Shows how many history entries that domain has in your history. Numbers will fluctuate if you have have older history automatically deleted."}
+							zIndex={1}
+						/>
+					</div>
+				</div>
+
+				<br /><br />
+				<div className="row">
+					<div className="col-md-12">
+						<button className="btn btn-danger" onClick={() => onResetButtonClick()}>
+							<span>Default Settings</span>
+						</button>
+						<Tooltip
+							text={"WARNING: This will also clear your expressions as well. So make a backup of them!"}
+						/>
+					</div>
 				</div>
 
 			</div>
-
-			<div className="row">
-				<div className="col-md-9">
-					<CheckboxSetting
-						text={"Log Total Number Of History Deleted"}
-						settingObject={settings.statLogging}
-						inline={true}
-						updateSetting={(payload) => onUpdateSetting(payload)}
-					/>
-					<Tooltip
-						text={"Counts the number of history deleted during this session and in total. This is shown in the Welcome Screen."}
-						zIndex={2}
-					/>
-				</div>
-
-				<div className="col-md-3">
-					<button onClick={() => onResetCounterButtonClick()} className="btn btn-warning" id="resetCounter">
-						<span>Reset Counter</span>
-					</button>
-				</div>
-
-			</div>
-
-			<div className="row">
-				<div className="col-md-12">
-					<CheckboxSetting
-						text={"Show Number of Visits In Browser Icon"}
-						settingObject={settings.showVisitsInIcon}
-						inline={true}
-						updateSetting={(payload) => onUpdateSetting(payload)}
-					/>
-					<Tooltip
-						text={"Shows how many history entries that domain has in your history. Numbers will fluctuate if you have have older history automatically deleted."}
-						zIndex={1}
-					/>
-				</div>
-			</div>
-
-			<br /><br />
-			<div className="row">
-				<div className="col-md-12">
-					<button className="btn btn-danger" onClick={() => onResetButtonClick()}>
-						<span>Default Settings</span>
-					</button>
-					<Tooltip
-						text={"WARNING: This will also clear your expressions as well. So make a backup of them!"}
-					/>
-				</div>
-			</div>
-
-		</div>
-	);
-};
+		);
+	}
+}
 
 HistorySettings.propTypes = {
 	style: PropTypes.object,


### PR DESCRIPTION
Adds a button to the History Settings page to allow the user to retroactively delete history that matches the list of expressions

fixes https://github.com/History-AutoDelete/History-AutoDelete/issues/63